### PR TITLE
Add Dockerfile and deployment instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM julia:latest
+
+# Install git
+RUN apt-get update \
+        && apt-get -y install git \
+        && rm -rf /var/cache/apt
+
+
+# Create unprivileged user
+ENV APPDIR="/app/"
+RUN useradd -d $APPDIR pkgserver \
+        && mkdir $APPDIR $APPDIR/storage \
+        && chown -R pkgserver:pkgserver $APPDIR
+USER pkgserver
+WORKDIR $APPDIR
+
+
+# Setup git
+RUN git config --global credential.helper \
+        '!f() { echo "username=${GIT_USER}\npassword=${GIT_PASSWORD}"; }; f'
+
+
+# Install LocalPackageServer
+ADD --chown=pkgserver:pkgserver *.toml $APPDIR/LocalPackageServer/
+ADD --chown=pkgserver:pkgserver src    $APPDIR/LocalPackageServer/src/
+RUN julia --project=LocalPackageServer \
+        -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
+
+
+# Run server
+ADD --chown=pkgserver:pkgserver deploy/run_server.jl .
+CMD ["julia", "--project=LocalPackageServer", "run_server.jl"]

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,39 @@
+## Example values
+## Use this template to create a `.env` file with appropriate values for your deployment
+
+
+## LocalPackageServer port
+## (mandatory)
+##
+SERVER_PORT=8000
+
+
+## URL to your local registry
+## (optional)
+##
+## If none is provided (by keeping the following line commented out) an empty
+## local registry is served (and the LocalPackageServer essentially acts as a
+## storage server only)
+##
+# JULIA_LOCAL_REGISTRY=https://git.example.com/MyJuliaRegistry.git
+
+
+## Credentials to be used to access the git repository of your local registry
+## (optional)
+##
+# GIT_USER=username
+# GIT_PASSWORD=p@ssw0rd
+
+
+## Package server which will serve requests for non-local packages
+## (optional)
+##
+## If left unset, https://pkg.julialang.org will be used.
+##
+# JULIA_PKG_SERVER=https://pkg.julialang.org
+
+
+## Minimum time (in seconds) before checking registries for updates
+## (optional)
+## 
+# MIN_TIME_BETWEEN_REGISTRY_UPDATES=60

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,0 +1,11 @@
+up:
+	docker-compose up --build --remove-orphans -d
+
+logs:
+	-docker-compose logs -f --tail=100
+
+down:
+	docker-compose down --remove-orphans
+
+destroy:
+	docker-compose down -v --remove-orphans

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,61 @@
+# Deployment of LocalPackageServer
+
+Deploying a `LocalPackageServer` instance in a docker environment should be as
+easy as filling out a `.env` file and running `make`.
+
+Here is a detailed, step-by-step deployment procedure:
+
+1. Clone this package and `cd` to the `deploy` directory:
+
+   ```
+   git clone https://github.com/GunnarFarneback/LocalPackageServer.jl.git
+   cd LocalPackageServer.jl/deploy
+   ```
+
+1. Fill out a `.env` file. You can start with the template provided in
+   `.env.example` and adapt it to your needs:
+   
+   ```
+   cp .env.example .env
+   $EDITOR .env
+   ```
+   
+   The `LocalPackageServer` behavior can be customized using the following
+   environment variables:
+   
+   - `SERVER_PORT`: port where `LocalPackageServer` will be
+     reachable. Mandatory, default value: `8000`.
+     
+   - `JULIA_LOCAL_REGISTRY`: URL of the local registry to be served. If this
+     variable is not set, `LocalPackageServer` will be configured as a storage
+     server only). Optional, unset by default.
+     
+   - `GIT_USER` and `GIT_PASSWORD`: git credentials to be used to access the
+     local registry. Optional, unset by default.
+     
+   - `JULIA_PKG_SERVER`: package server which will serve requests for non-local
+     packages. Optional, default value: `https://pkg.julialang.org`.
+ 
+   - `MIN_TIME_BETWEEN_REGISTRY_UPDATES`: minimum time (in seconds) before
+     checking registries for updates. Optional, default value: `60`.
+     
+1. Start the server using `make`:
+
+   ```
+   make up
+   ```
+   
+   The following `make` verbs are supported:
+   
+   - `up`: start the server container in the background (after having built the
+     Docker image if necessary).
+     
+   - `logs`: display the server logs (you'll have to kill this with
+     <kbd>Ctrl+c</kbd> when you're done).
+     
+   - `down`: stop the server container.
+   
+   - `destroy`: stop the server container and remove the persistent volumes
+     attached to it.
+
+

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.3"
+services:
+  pkgserver:
+    build: ..
+    ports:
+      - "${SERVER_PORT}:8000"
+    volumes:
+      - storage:/app/storage
+    environment:
+      - MIN_TIME_BETWEEN_REGISTRY_UPDATES
+      - JULIA_PKG_SERVER
+      - JULIA_LOCAL_REGISTRY
+      - GIT_USER
+      - GIT_PASSWORD
+
+volumes:
+  storage:

--- a/deploy/run_server.jl
+++ b/deploy/run_server.jl
@@ -1,0 +1,34 @@
+using LocalPackageServer
+
+config = Dict(
+    # Server parameters
+    "host" => "0.0.0.0",
+    "port" => 8000,
+
+    # This is where persistent data will be stored
+    "cache_dir"      => abspath("/app/storage/cache"),
+    "git_clones_dir" => abspath("/app/storage/data"),
+)
+
+# Package server to be used for non-local packages
+# If none is provided, use pkg.julialang.org
+config["pkg_server"] = get(ENV, "JULIA_PKG_SERVER", "https://pkg.julialang.org")
+
+# Min time between checking registries for updates (default: 1 minute)
+config["min_time_between_registry_updates"] = parse(Int, get(ENV, "MIN_TIME_BETWEEN_REGISTRY_UPDATES", "60"))
+
+# Local registry: if none is provided LocalPackageServer turns into a storage
+# server only
+if "JULIA_LOCAL_REGISTRY" in keys(ENV)
+    config["local_registry"] = ENV["JULIA_LOCAL_REGISTRY"]
+else
+    @warn "No local registry provided; behaving as a storage server."
+end
+
+@info("Local package server configuration:",
+      pkg_server = config["pkg_server"],
+      local_registry = get(config, "local_registry", "<STORAGE SERVER ONLY>"),
+      min_time_between_registry_updates = config["min_time_between_registry_updates"],
+      )
+
+LocalPackageServer.start(LocalPackageServer.Config(config))


### PR DESCRIPTION
I've been using a `docker` + `docker-compose` setup to deploy `LocalPackageServer` instances in my local network, and thought it could be of relatively general use (which I think is confirmed by #1).

This PR implements a deployment procedure based on `docker-compose` and customizable via a `.env` configuration file (a setup which is largely inspired by [`PkgServer.jl`](https://github.com/JuliaPackaging/PkgServer.jl/tree/master/deployment)). Everything should be documented in the `deploy/README.md` file, but please feel free to ask for more documentation if you feel like some details are missing.

Of course, comments & criticism are welcome!

If this PR is merged, deploying a `LocalPackageServer` instance should be as easy as cloning the git repo, editing the `.env` file and running make. As a further step, it should be possible to [integrate this github repo with docker hub](https://docs.docker.com/docker-hub/builds/), which IIUC would allow docker hub to always provide an up-to-date image for `LocalPackageServer` (in much the same way as one is available for [`PkgServer`](https://hub.docker.com/r/juliapackaging/pkgserver.jl)). If we decide to go down that route, deploying a `LocalPackageServer` instance could become as simple as running one `docker` (or `docker-compose`) command, without having to clone or install anything on the host machine.