### PR TITLE
Update compat of HTTP and LocalRegistry.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,17 +14,17 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [compat]
 CodecZlib = "0.7"
-HTTP = "0.8"
+HTTP = "0.8, 0.9"
 Inflate = "0.1"
-julia = "1.4"
-LocalRegistry = "0.3"
+LocalRegistry = "0.4"
 RegistryTools = "1.2"
 Tar = "1.4"
+julia = "1.4"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-LocalRegistry = "89398ba2-070a-4b16-a995-9893c55d93cf"
 Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+LocalRegistry = "89398ba2-070a-4b16-a995-9893c55d93cf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "LocalRegistry", "Inflate"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,7 @@ mktempdir(@__DIR__) do test_dir
     prepare_package(packages_dir, "FirstTest1.toml")
     first_test_dir = joinpath(packages_dir, "FirstTest")
     first_test_url = "file://$(first_test_dir)"
-    register(first_test_dir, registry_dir,
+    register(first_test_dir, registry = registry_dir,
              repo = first_test_url, 
              gitconfig = TEST_GITCONFIG, push = true)
     first_test_uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"


### PR DESCRIPTION
Add compat for HTTP 0.9 without changing any code. It passes the tests but it's not easy to find information about what was breaking in HTTP 0.9.

Update LocalRegistry compat from 0.3 to 0.4 (test dependency only).
