### PR TITLE
Update resource.jl

### DIFF
--- a/src/resource.jl
+++ b/src/resource.jl
@@ -164,7 +164,7 @@ end
 function serve_file(http::HTTP.Stream, path::String)
     HTTP.setheader(http, "Content-Length" => string(filesize(path)))
     # We assume that everything we send is gzip-compressed (since they're all tarballs)
-    HTTP.setheader(http, "Content-Encoding" => "gzip")
+    HTTP.setheader(http, "Content-Type" => "application/octet-stream")
     startwrite(http)
 
     # Open the path, write it out directly to the HTTP stream


### PR DESCRIPTION
the header "Content-Encoding" => "gzip" triggers the unzipping to happen twice (once by the chromium engine, and a second time by the package manager).  It is better to remove it and replace by the same header that the Package Server uses, i.e. "Content-Type" => "application/octet-stream".