### PR TITLE
Updates August 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 name: CI
 on:
-  pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - master
-    tags: '*'
+    branches: [master]
+    tags: ["*"]
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -25,24 +22,15 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # Julia LTS version.
+          - '1.10' # Julia LTS version and lowest supported.
           - '1'   # Expands to latest 1.x.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.0"
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -19,7 +20,7 @@ LocalRegistry = "0.4, 0.5"
 RegistryInstances = "0.1"
 RegistryTools = "1.2, 2"
 Tar = "1.4"
-julia = "1.4"
+julia = "1.10"
 
 [extras]
 Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"

--- a/Project.toml
+++ b/Project.toml
@@ -8,13 +8,13 @@ CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [compat]
 CodecZlib = "0.7"
-HTTP = "0.8, 0.9, 1.3"
+HTTP = "1.3"
 Inflate = "0.1"
 LocalRegistry = "0.4, 0.5"
 RegistryInstances = "0.1"
@@ -25,10 +25,10 @@ julia = "1.10"
 [extras]
 Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 LocalRegistry = "89398ba2-070a-4b16-a995-9893c55d93cf"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [targets]
-test = ["Test", "LocalRegistry", "Inflate", "RegistryInstances", "RegistryTools", "TOML"]
+test = ["Test", "LocalRegistry", "Inflate", "RegistryInstances", "RegistryTools", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,15 @@
 name = "LocalPackageServer"
 uuid = "5ed2caf0-0e3c-46c8-ab7c-f67841b915e6"
-authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
 version = "0.2.0"
+authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+LoggingFormats = "98105f81-4425-4516-93fd-1664fb551ab6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
@@ -17,6 +19,8 @@ CodecZlib = "0.7"
 HTTP = "1.3"
 Inflate = "0.1"
 LocalRegistry = "0.4, 0.5"
+LoggingExtras = "1"
+LoggingFormats = "1"
 RegistryInstances = "0.1"
 RegistryTools = "1.2, 2"
 Tar = "1.4"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ your local registry is done as above after you have pointed
     yet. This can be useful if the repository is very large and/or it
     is unlikely that making a new clone will succeed when an update
     fails.
+* `log_format`: Format for log entries. Options:
+  * `text`: Default Julia log entries.
+  * `json`: JSON-formatted logs.
 * `gitconfig`: Extra configuration for git when cloning or pulling
   local registries and packages. This is specified as a key/value
   mapping, e.g.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ pkg_server = "https://pkg.julialang.org"
 cache_dir = "/tmp/cache"
 git_clones_dir = "/tmp/data"
 min_time_between_registry_updates = 60
+repository_clone_strategy = "on_failure"
 ```
 Replace `REGISTRY_URL` with the URL to your local registry (the same
 that you would use in a `registry add` command). If you want to use
@@ -52,14 +53,15 @@ this package server:
 $ JULIA_PKG_SERVER=http://localhost:8000 julia
 ```
 
-In order to add your registry through the package server, you need to do
+In order to add your registry through the package server, for Julia
+1.4 you need to do
 ```
 using Pkg
 pkg"registry add UUID"
 ```
 where `UUID` is the UUID of your local registry.
 
-For Julia 1.5 you won't need to specify the UUID;
+For Julia 1.5 and later you won't need to specify the UUID;
 ```
 using Pkg
 pkg"registry add"
@@ -99,6 +101,18 @@ your local registry is done as above after you have pointed
 * `min_time_between_registry_updates`: Minimum time in seconds before
   checking registries for updates. Updates are only triggered when
   either a package or a repository is requested.
+* `repository_clone_strategy`: Whether to clone or update registry
+  and package repositories when new versions are requested. Options:
+  * `"always"`: Clone every time. This is conservative but may be
+    unnecessarily slow.
+  * `"on_failure"`: Try to update if possible but make a new clone if
+    update fails. This is the default option and in particular
+    helpful if the failure happened because the repository URL or
+    credentials had changed.
+  * `"if_missing"`: Only clone if the repository has not been cloned
+    yet. This can be useful if the repository is very large and/or it
+    is unlikely that making a new clone will succeed when an update
+    fails.
 * `gitconfig`: Extra configuration for git when cloning or pulling
   local registries and packages. This is specified as a key/value
   mapping, e.g.

--- a/src/LocalPackageServer.jl
+++ b/src/LocalPackageServer.jl
@@ -14,7 +14,7 @@ using HTTP
 using Random
 using Tar
 import Downloads
-using LoggingExtras: FormatLogger, global_logger
+using LoggingExtras: FormatLogger, MinLevelLogger, Info, global_logger
 import LoggingFormats
 
 include("config.jl")
@@ -28,7 +28,8 @@ function __init__()
 end
 
 function setup_json_logger()
-    global_logger(FormatLogger(LoggingFormats.JSON(; recursive=true)))
+    l = MinLevelLogger(FormatLogger(LoggingFormats.JSON(; recursive=true, nest_kwargs=false)), Info)
+    global_logger(l)
 end
 
 start(config) = start(Config(config))

--- a/src/LocalPackageServer.jl
+++ b/src/LocalPackageServer.jl
@@ -9,11 +9,11 @@ See the package's `README.md` for more information.
 """
 module LocalPackageServer
 
-using Pkg
 using Dates
 using HTTP
 using Random
 using Tar
+import Downloads
 
 include("config.jl")
 include("resource.jl")

--- a/src/LocalPackageServer.jl
+++ b/src/LocalPackageServer.jl
@@ -14,6 +14,8 @@ using HTTP
 using Random
 using Tar
 import Downloads
+using LoggingExtras: FormatLogger, global_logger
+import LoggingFormats
 
 include("config.jl")
 include("resource.jl")
@@ -25,11 +27,17 @@ function __init__()
     HTTP.setuseragent!("LocalPackageServer (HTTP.jl)")
 end
 
+function setup_json_logger()
+    global_logger(FormatLogger(LoggingFormats.JSON(; recursive=true)))
+end
+
 start(config) = start(Config(config))
 
 function start(config::Config)
     isempty(config.storage_servers) && throw(@error "No storage servers are configured." resource=resource)
 
+    # Configure JSON logs if requested (:text format requires no config)
+    config.log_format == :json && setup_json_logger()
     host = config.host
     port = config.port
     mkpath(config.cache_dir)

--- a/src/config.jl
+++ b/src/config.jl
@@ -21,6 +21,7 @@ mutable struct Config
     git_clones_dir::String
     min_time_between_registry_updates::Int
     repository_clone_strategy::Symbol
+    log_format::Symbol
     gitconfig::Dict{String, String}
 end
 
@@ -47,6 +48,14 @@ function Config(data::Dict)
         error("Unknown repository_clone_strategy: $s\n",
               "Valid options are ", join(strategies, ", "), ".")
     end
+    f = get(data, "log_format", "text")
+    log_formats = ["text", "json"]
+    if f in log_formats
+        log_format = Symbol(f)
+    else
+        error("Unknown log_format: $f\n",
+              "Valid options are ", join(log_formats, ", "), ".")
+    end
     gitconfig = get(data, "gitconfig", Dict{String, String}())
 
     storage_servers = Union{GitStorageServer, PkgStorageServer}[]
@@ -69,5 +78,5 @@ function Config(data::Dict)
     git_clones_dir = rstrip(git_clones_dir, ['/', '\\'])
 
     return Config(host, port, storage_servers, cache_dir, git_clones_dir,
-                  min_time, strategy, gitconfig)
+                  min_time, strategy, log_format, gitconfig)
 end

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -2,7 +2,7 @@
 
 function get_pkgserver_version()
     # Get PkgServer.jl's version and git sha
-    version = Pkg.TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))["version"]
+    version = TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))["version"]
     try
         repo = LibGit2.GitRepo(dirname(@__DIR__))
         gitsha = string(LibGit2.GitHash(LibGit2.GitCommit(repo, "HEAD")))


### PR DESCRIPTION
This PR tries to make LocalPackageServer a little more robust, primarily by adding a new configuration variable to control when to make a fresh clone of a repository instead of updating it. This is specifically designed to support updates of HTTPS credentials, which may be baked into registered package URLs ~or enter through git insteadOf configuration~. Edit: the `git insteadOf` mechanism is inherently robust to such updates.

Important, if you for some reason want to keep the old behavior, you should set `repository_clone_strategy` to `if_missing` instead of the default `on_failure`.

Another important fix is the use of `Downloads.download` instead of `HTTP.get` to avoid the [redirection bug #1165](https://github.com/JuliaWeb/HTTP.jl/issues/1165 ) in recent `HTTP` versions.

The Julia compat is bumped to 1.10, the current LTS version.
