### PR TITLE
Allow JSON logging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,15 @@
 name = "LocalPackageServer"
 uuid = "5ed2caf0-0e3c-46c8-ab7c-f67841b915e6"
-authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
 version = "0.2.0"
+authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+LoggingFormats = "98105f81-4425-4516-93fd-1664fb551ab6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
@@ -17,6 +19,8 @@ CodecZlib = "0.7"
 HTTP = "1.3"
 Inflate = "0.1"
 LocalRegistry = "0.4, 0.5"
+LoggingExtras = "1"
+LoggingFormats = "1"
 RegistryInstances = "0.1"
 RegistryTools = "1.2, 2"
 Tar = "1.4"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ your local registry is done as above after you have pointed
     yet. This can be useful if the repository is very large and/or it
     is unlikely that making a new clone will succeed when an update
     fails.
+* `log_format`: Format for log entries. Options:
+  * `text`: Default Julia log entries.
+  * `json`: JSON-formatted logs.
 * `gitconfig`: Extra configuration for git when cloning or pulling
   local registries and packages. This is specified as a key/value
   mapping, e.g.

--- a/src/LocalPackageServer.jl
+++ b/src/LocalPackageServer.jl
@@ -14,6 +14,8 @@ using HTTP
 using Random
 using Tar
 import Downloads
+using LoggingExtras: FormatLogger, global_logger
+import LoggingFormats
 
 include("config.jl")
 include("resource.jl")
@@ -25,11 +27,17 @@ function __init__()
     HTTP.setuseragent!("LocalPackageServer (HTTP.jl)")
 end
 
+function setup_json_logger()
+    global_logger(FormatLogger(LoggingFormats.JSON(; recursive=true)))
+end
+
 start(config) = start(Config(config))
 
 function start(config::Config)
     isempty(config.storage_servers) && throw(@error "No storage servers are configured." resource=resource)
 
+    # Configure JSON logs if requested (:text format requires no config)
+    config.log_format == :json && setup_json_logger()
     host = config.host
     port = config.port
     mkpath(config.cache_dir)

--- a/src/config.jl
+++ b/src/config.jl
@@ -21,6 +21,7 @@ mutable struct Config
     git_clones_dir::String
     min_time_between_registry_updates::Int
     repository_clone_strategy::Symbol
+    log_format::Symbol
     gitconfig::Dict{String, String}
 end
 
@@ -47,6 +48,14 @@ function Config(data::Dict)
         error("Unknown repository_clone_strategy: $s\n",
               "Valid options are ", join(strategies, ", "), ".")
     end
+    f = get(data, "log_format", "text")
+    log_formats = ["text", "json"]
+    if f in log_formats
+        log_format = Symbol(f)
+    else
+        error("Unknown log_format: $f\n",
+              "Valid options are ", join(log_formats, ", "), ".")
+    end
     gitconfig = get(data, "gitconfig", Dict{String, String}())
 
     storage_servers = Union{GitStorageServer, PkgStorageServer}[]
@@ -69,5 +78,5 @@ function Config(data::Dict)
     git_clones_dir = rstrip(git_clones_dir, ['/', '\\'])
 
     return Config(host, port, storage_servers, cache_dir, git_clones_dir,
-                  min_time, strategy, gitconfig)
+                  min_time, strategy, log_format, gitconfig)
 end


### PR DESCRIPTION
This adds the option to log in JSON format. It only changes the Julia logs, nothing about Git output or anything like that. It basically follows the first example in the [LoggingFormats readme](https://github.com/JuliaLogging/LoggingFormats.jl#json-output-log-events-as-json).