### PR TITLE
Update the Git remote URL before fetching an existing clone

### DIFF
--- a/src/gitserver.jl
+++ b/src/gitserver.jl
@@ -77,6 +77,8 @@ function clone_or_update_repository(config, path, repo, hash = nothing)
         end
         if update_needed
             try
+                # Update the remote URL, in case the repository has moved.
+                run(`$git remote set-url origin $(repo)`)
                 run(`$git remote update`)
             catch e
                 @error "Failed to update $(repo)." error = e


### PR DESCRIPTION
**Dilum's PR description:**

Situation 1: Suppose you do the following:
1. Shut down the Pkg server
2. Edit the configuration TOML file, and change the URL of the `local_registry`
3. Start up the Pkg server

In that situation, we should update the Git remote URL of the local clone of the registry. This PR does that.

Situation 2: Suppose that you edit your registry and change the URL of one of the registered packages. In this situation, if the package is already cloned, we should update the Git remote URL of the local clone of the package. This PR does that.

Note: This is only relevant if your `repository_clone_strategy` is either `on_failure` (the default value) or `if_missing`. It won't make a difference if you set `repository_clone_strategy = "always"`.

---

🤖 **Claude Code PR description:**

`clone_or_update_repository` refreshes an existing clone with `git remote update`. That fetches from the remote recorded in the clone, not from the URL that is currently configured. When a registry or a package repository moves, the server therefore keeps fetching from the old URL and silently serves outdated contents.

It only recovers if the old URL *starts failing* and `repository_clone_strategy` is `on_failure`. If the old location is still reachable — a mirror that was left in place, a redirect that still resolves — the update succeeds and nothing indicates that the contents are stale.

This sets the remote URL from the configured repository before updating. The new command sits inside the existing `try`, so a clone without an `origin` remote still falls back to the established re-clone path, and it is skipped entirely when no update is needed (the requested hash is already present, so the remote does not matter).

Applies to both the local registry and to package repositories, whose `repo` URLs come from the registry's `Package.toml`.

### Not addressed

`git remote update` on a mirror force-updates refs but does not prune refs the new remote no longer has, so a re-pointed clone can retain stale refs. That is harmless here, since clients only request hashes the server advertises, and adding `--prune` would change behavior for every repository.

### Test

No test is included. An earlier revision added one — it created a registry, served `/registries`, copied the bare repository to a second location, added a commit there, and pointed the configuration at the new URL while reusing the same `git_clones_dir`, with the old location deliberately left in place and working. It was verified to fail before the change and pass after, but dropped in review as disproportionate to a one-line fix.

🤖 Assisted-by: Claude Code:claude-opus-5[1m]

