### PR TITLE
Make sure that `repo` is defined, in case we want to use it in an `@error` message

### DIFF
--- a/src/gitserver.jl
+++ b/src/gitserver.jl
@@ -99,6 +99,7 @@ function get_resource_from_storage_server!(config, server::GitStorageServer,
     registry_dir = get_local_registry_dir(config)
     if parts[1] == "registry"
         git = gitcmd(config, registry_dir)
+        repo = server.url
         uuid = parts[2]
         hash = parts[3]
         uuid != server.uuid && return false


### PR DESCRIPTION
Prior to this PR, if you're in the `if parts[1] == "registry"` branch, the `repo` variable never gets defined. So then, further down, you could hit an `@error` message that expects the `repo` variable to be defined.

So this PR just makes sure to define the `repo` variable in the `if parts[1] == "registry"` branch.

🤖 Assisted-by: Claude Code:claude-opus-5[1m]
