### PR TITLE
Keep the output stream open when a resource (treehash) is not available from one `GitStorageServer`

### DIFF
--- a/src/gitserver.jl
+++ b/src/gitserver.jl
@@ -130,7 +130,7 @@ function get_resource_from_storage_server!(config, server::GitStorageServer,
         read(`$git rev-parse --verify --quiet $(hash)^\{tree\}`)
     catch
         @error "Hash not available in repository" repo=repo hash=hash Dates.now()
-        close(io)
+        # Leave `io` open, in case a subsequent `StorageServer` has the desired treehash
         return false
     end
 


### PR DESCRIPTION
🤖 **Claude Code PR description:**

### Before this PR

`fetch_resource` hands the *same* `io` to each configured `StorageServer` in turn. However, in the "_hash not available in repository_" path, the `GitStorageServer` closes that `io` before returning `false`.

So, if a later `StorageServer` has the desired treehash, it will try to write into a closed `io`. Unfortunately, attempting to write to a closed `IOStream` silently returns `0` and discards the bytes. As a consequence:
1. The temporary file stays empty.
2. `LocalPackageServer.download` throws while verifying the treehash.
3. The client (Pkg) gets a 404 for a resource that another upstream `StorageServer` might have actually had.

### What this PR changes

Deletes that `close(io)` call.

### After this PR

If `GitStorageServer` doesn't have the `treehash`, it leaves the `io` open for the next `StorageServer`.

The fetch task (that is spawned by `cached_fetch_resource`) closes the `io` at [`resource.jl:157`](https://github.com/GunnarFarneback/LocalPackageServer.jl/blob/9e5f2a87679ff4bcce49c3f38883746f75b93fbb/src/resource.jl#L157), regardless of whether or not any `StorageServer` had the resource. So the `io` will eventually get closed.

### Motivation

I'm working on a follow-up PR that will allow LocalPackageServer to serve multiple local registries, and I think I need this fix first.

🤖 Assisted-by: Claude Code:claude-opus-5[1m]